### PR TITLE
Fix conditional error resetting has_pw1 variable

### DIFF
--- a/src/openpgp/openpgp.c
+++ b/src/openpgp/openpgp.c
@@ -473,7 +473,7 @@ int inc_sig_count() {
     if (!(pw_status = search_by_fid(EF_PW_PRIV, NULL, SPECIFY_EF)) || !pw_status->data) {
         return SW_REFERENCE_NOT_FOUND();
     }
-    if (file_get_data(pw_status)[0] == 1) {
+    if (file_get_data(pw_status)[0] == 0) {
         has_pw1 = false;
     }
     file_t *ef = search_by_fid(EF_SIG_COUNT, NULL, SPECIFY_ANY);


### PR DESCRIPTION
According to OpenPGP 3.4.1 specifications subsection 4.4.1:

```
PW status Bytes
1st byte: 00 = PW1 (no. 81) only valid for one PSO:CDS command
          01 = PW1 valid for several PSO:CDS commands
```

Therefore has_pw1 should be reset to false when the first byte of the PW status is 0 instead of 1.
This resulted in issue #16